### PR TITLE
feat(idletime) implements max idle session time

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ support for these backends:
 * `shm` aka Lua Shared Dictionary
 * `memcache` aka Memcached Storage Backend (thanks [@zandbelt](https://github.com/zandbelt))
 * `redis` aka Redis Backend
+* `dshm`
 
 Here are some comparisons about the backends:
 
@@ -824,6 +825,15 @@ local uid = session.data.uid
 `session.expires` holds the expiration time of the session (expiration time will be generated when
 `session:save` method is called).
 
+#### number session.usebefore
+
+`session.usebefore` holds the expiration time based on session usgae (expiration time will be generated
+when the session is saved or started). This iexpiry time is only stored client-side in the cookie.
+Note that just opening a session will not update the cookie! To mark the session as used you must call
+`session:start`. (You can also use `session:save` but that will also write session data to the
+storage, whereas just calling `start` reads the session data and updates the `usebefore` value in the
+client-side cookie without writing to the storage, it will just be setting a new cookie)
+
 #### string session.secret
 
 `session.secret` holds the secret that is used in keyed HMAC generation.
@@ -854,6 +864,12 @@ to 3,600 seconds. This can be configured with Nginx `set $session_cookie_lifetim
 set cookie's expiration time on session only (by default) cookies, but it is used if the cookies are
 configured persistent with `session.cookie.persistent == true`. See also notes about
 [ssl_session_timeout](#nginx-configuration-variables).
+
+#### number session.cookie.idletime
+
+`session.cookie.idletime` holds the cookie idletime in seconds in the future. If a cookie is not used
+(idle) for this time, the session becomes invalid. By default this is set to 0 seconds, meaning it is
+disabled. This can be configured with Nginx `set $session_cookie_idletime 300;`.
 
 #### string session.cookie.path
 
@@ -1017,6 +1033,7 @@ set $session_cookie_persistent off;
 set $session_cookie_discard    10;
 set $session_cookie_renew      600;
 set $session_cookie_lifetime   3600;
+set $session_cookie_idletime   0;
 set $session_cookie_path       /;
 set $session_cookie_domain     openresty.org;
 set $session_cookie_samesite   Lax;

--- a/lib/resty/session.lua
+++ b/lib/resty/session.lua
@@ -164,7 +164,8 @@ end
 -- read the cookie for the session object.
 -- @param session_obj (table) the session object for which to read the cookie
 -- @param i (number) do not use! internal recursion variable
--- @return string with cookie data (and the property `session.cookie.chunks` will be set to the actual number of chunks read)
+-- @return string with cookie data (and the property `session.cookie.chunks`
+-- will be set to the actual number of chunks read)
 local function getcookie(session_obj, i)
     local name = session_obj.name
     local n = { "cookie_", name }
@@ -304,13 +305,20 @@ function session.new(opts)
     opts = type(opts) == "table" and opts or defaults
     local cookie_opts, cookie_defaults = opts.cookie or defaults.cookie, defaults.cookie
     local check_opts,  check_defaults = opts.check  or defaults.check,  defaults.check
-    local ident_mod,  ident_name  = prequire("resty.session.identifiers.", opts.identifier or defaults.identifier, "random")
-    local serial_mod, serial_name = prequire("resty.session.serializers.", opts.serializer or defaults.serializer, "json")
-    local enc_mod,    enc_name    = prequire("resty.session.encoders.",    opts.encoder    or defaults.encoder,    "base64")
-    local ciph_mod,   ciph_name   = prequire("resty.session.ciphers.",     opts.cipher     or defaults.cipher,     "aes")
-    local stor_mod,   stor_name   = prequire("resty.session.storage.",     opts.storage    or defaults.storage,    "cookie")
-    local strat_mod,  strat_name  = prequire("resty.session.strategies.",  opts.strategy   or defaults.strategy,   "default")
-    local hmac_mod,   hmac_name   = prequire("resty.session.hmac.",        opts.hmac       or defaults.hmac,       "sha1")
+    local ident_mod,  ident_name  = prequire("resty.session.identifiers.",
+                                    opts.identifier or defaults.identifier, "random")
+    local serial_mod, serial_name = prequire("resty.session.serializers.",
+                                    opts.serializer or defaults.serializer, "json")
+    local enc_mod,    enc_name    = prequire("resty.session.encoders.",
+                                    opts.encoder    or defaults.encoder,    "base64")
+    local ciph_mod,   ciph_name   = prequire("resty.session.ciphers.",
+                                    opts.cipher     or defaults.cipher,     "aes")
+    local stor_mod,   stor_name   = prequire("resty.session.storage.",
+                                    opts.storage    or defaults.storage,    "cookie")
+    local strat_mod,  strat_name  = prequire("resty.session.strategies.",
+                                    opts.strategy   or defaults.strategy,   "default")
+    local hmac_mod,   hmac_name   = prequire("resty.session.hmac.",
+                                    opts.hmac       or defaults.hmac,       "sha1")
     local self = {
         name       = opts.name   or defaults.name,
         identifier = ident_mod,

--- a/lib/resty/session/storage/cookie.lua
+++ b/lib/resty/session/storage/cookie.lua
@@ -58,7 +58,13 @@ end
 -- @param hash (string)
 -- @return encoded cookie-string value
 function cookie:save(id, usebefore, expires, data, hash)
-    return concat({ self.encode(id), tostring(usebefore), tostring(expires), self.encode(data), self.encode(hash) }, self.delimiter)
+    return concat({
+        self.encode(id),
+        tostring(usebefore),
+        tostring(expires),
+        self.encode(data),
+        self.encode(hash)
+    }, self.delimiter)
 end
 
 cookie.touch = cookie.save  -- identical in the 'cookie' case

--- a/lib/resty/session/storage/cookie.lua
+++ b/lib/resty/session/storage/cookie.lua
@@ -18,11 +18,12 @@ end
 -- @param value (string) the string to split in the elements
 -- @return array with the elements in order, or `nil` if the number of elements do not match expectations.
 function cookie:cookie(value)
+    local size = 5
     local result, delim = {}, self.delimiter
     local count, pos = 1, 1
     local match_start, match_end = value:find(delim, 1, true)
     while match_start do
-        if count > 3 then
+        if count == size then
             return nil  -- too many elements
         end
         result[count] = value:sub(pos, match_end - 1)
@@ -30,20 +31,20 @@ function cookie:cookie(value)
         pos = match_end + 1
         match_start, match_end = value:find(delim, pos, true)
     end
-    if count ~= 4 then
-        return nil  -- too little elements (4 expected)
+    if count ~= size then
+        return nil  -- too little elements
     end
-    result[4] = value:sub(pos)
+    result[size] = value:sub(pos)
     return result
 end
 
--- returns 4 decoded data elements from the cookie-string
+-- returns 5 decoded data elements from the cookie-string
 -- @param value (string) the cookie string containing the encoded data.
--- @return id (string), expires(number), data (string), hash (string).
+-- @return id (string), usebefore(number), expires(number), data (string), hash (string).
 function cookie:open(value)
     local r = self:cookie(value)
     if r and r[1] and r[2] and r[3] and r[4] then
-        return self.decode(r[1]), tonumber(r[2]), self.decode(r[3]), self.decode(r[4])
+        return self.decode(r[1]), tonumber(r[2]), tonumber(r[3]), self.decode(r[4]), self.decode(r[5])
     end
     return nil, "invalid"
 end
@@ -51,12 +52,15 @@ end
 -- returns a cookie-string. Note that the cookie-storage does not store anything
 -- server-side in this case.
 -- @param id (string)
--- @param expires(number)
+-- @param usebefore (number)
+-- @param expires (number)
 -- @param data (string)
 -- @param hash (string)
 -- @return encoded cookie-string value
-function cookie:save(id, expires, data, hash)
-    return concat({ self.encode(id), tostring(expires), self.encode(data), self.encode(hash) }, self.delimiter)
+function cookie:save(id, usebefore, expires, data, hash)
+    return concat({ self.encode(id), tostring(usebefore), tostring(expires), self.encode(data), self.encode(hash) }, self.delimiter)
 end
+
+cookie.touch = cookie.save  -- identical in the 'cookie' case
 
 return cookie

--- a/lib/resty/session/strategies/default.lua
+++ b/lib/resty/session/strategies/default.lua
@@ -6,10 +6,14 @@ local default = {}
 
 
 local function update(handler, session_obj, close)
-  local id, usebefore, expires, storage = session_obj.id, session_obj.usebefore, session_obj.expires, session_obj.storage
+  local id = session_obj.id
+  local usebefore = session_obj.usebefore
+  local expires = session_obj.expires
+  local storage = session_obj.storage
   local key = session_obj.hmac(session_obj.secret, id .. expires)
   local data = session_obj.serializer.serialize(session_obj.data)
-  local hash = session_obj.hmac(key, concat{ id, usebefore, expires, data, session_obj.key })
+  local hash = session_obj.hmac(key,
+               concat{ id, usebefore, expires, data, session_obj.key })
 
   data = session_obj.cipher:encrypt(data, key, id, session_obj.key)
   return handler(storage, id, usebefore, expires, data, hash, close)
@@ -35,7 +39,8 @@ end
 -- Validates the expiry-time and hash.
 -- @param session_obj (table) the session object to store the data in
 -- @param cookie (string) the cookie string to open
--- @return `true` if ok, and will have set session properties; id, expires, data and present. Returns `nil` otherwise.
+-- @return `true` if ok, and will have set session properties; id, expires, data
+-- and present. Returns `nil` otherwise.
 function default.open(session_obj, cookie)
   local id, usebefore, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
   local now = time()

--- a/lib/resty/session/strategies/default.lua
+++ b/lib/resty/session/strategies/default.lua
@@ -4,17 +4,31 @@ local concat = table.concat
 
 local default = {}
 
+
+local function update(handler, session_obj, close)
+  local id, usebefore, expires, storage = session_obj.id, session_obj.usebefore, session_obj.expires, session_obj.storage
+  local key = session_obj.hmac(session_obj.secret, id .. expires)
+  local data = session_obj.serializer.serialize(session_obj.data)
+  local hash = session_obj.hmac(key, concat{ id, usebefore, expires, data, session_obj.key })
+
+  data = session_obj.cipher:encrypt(data, key, id, session_obj.key)
+  return handler(storage, id, usebefore, expires, data, hash, close)
+end
+
 -- save the session data to the underlying storage adapter.
 -- @param session_obj (table) the session object to store
 -- @return result from `storage.save`.
 function default.save(session_obj, close)
-  local id, expires, storage = session_obj.id, session_obj.expires, session_obj.storage
-  local key = session_obj.hmac(session_obj.secret, id .. expires)
-  local data = session_obj.serializer.serialize(session_obj.data)
-  local hash = session_obj.hmac(key, concat{ id, expires, data, session_obj.key })
+  return update(session_obj.storage.save, session_obj, close)
+end
 
-  data = session_obj.cipher:encrypt(data, key, id, session_obj.key)
-  return storage:save(id, expires, data, hash, close)
+-- Generates a new cookie, without writing to the store.
+-- Used when 'idletime' is used and 'usebefore' is altered without the content being
+-- changed.
+-- @param session_obj (table) the session object to store
+-- @return result from `storage.save`.
+function default.touch(session_obj, close)
+  return update(session_obj.storage.touch, session_obj, close)
 end
 
 -- Calls into the underlying storage adapter to load the cookie.
@@ -23,13 +37,18 @@ end
 -- @param cookie (string) the cookie string to open
 -- @return `true` if ok, and will have set session properties; id, expires, data and present. Returns `nil` otherwise.
 function default.open(session_obj, cookie)
-  local id, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
-  if id and expires and expires > time() and data and hash then
+  local id, usebefore, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
+  local now = time()
+  if id and
+     expires and expires > now and
+     usebefore and usebefore > now and
+     data and hash then
     local key = session_obj.hmac(session_obj.secret, id .. expires)
     data = session_obj.cipher:decrypt(data, key, id, session_obj.key)
-    if data and session_obj.hmac(key, concat{ id, expires, data, session_obj.key }) == hash then
+    if data and session_obj.hmac(key, concat{ id, usebefore, expires, data, session_obj.key }) == hash then
       data = session_obj.serializer.deserialize(data)
       session_obj.id = id
+      session_obj.usebefore = usebefore
       session_obj.expires = expires
       session_obj.data = type(data) == "table" and data or {}
       session_obj.present = true

--- a/lib/resty/session/strategies/regenerate.lua
+++ b/lib/resty/session/strategies/regenerate.lua
@@ -8,7 +8,11 @@ local regenerate = {}
 -- @param session_obj (table) the session object to store
 -- @return result from `storage.save`.
 function regenerate.save(session_obj, close)
-  local id, usebefore, expires, storage = session_obj.id, session_obj.usebefore, session_obj.expires, session_obj.storage
+  local id = session_obj.id
+  local usebefore = session_obj.usebefore
+  local expires = session_obj.expires
+  local storage = session_obj.storage
+
   if storage.ttl then
     -- if there is a ttl, then we set the lifetime to the 'discard' value as a
     -- grace period
@@ -31,7 +35,11 @@ end
 -- @param session_obj (table) the session object to store
 -- @return result from `storage.save`.
 function regenerate.touch(session_obj, close)
-  local id, usebefore, expires, storage = session_obj.id, session_obj.usebefore, session_obj.expires, session_obj.storage
+  local id = session_obj.id
+  local usebefore = session_obj.usebefore
+  local expires = session_obj.expires
+  local storage = session_obj.storage
+
   local key = session_obj.hmac(session_obj.secret, id)
   local data = session_obj.serializer.serialize(session_obj.data)
   local hash = session_obj.hmac(key, concat{ id, usebefore, data, session_obj.key })
@@ -44,7 +52,8 @@ end
 -- Validates the expiry-time and hash.
 -- @param session_obj (table) the session object to store the data in
 -- @param cookie (string) the cookie string to open
--- @return `true` if ok, and will have set session properties; id, usebefore, expires, data and present. Returns `nil` otherwise.
+-- @return `true` if ok, and will have set session properties; id, usebefore,
+-- expires, data and present. Returns `nil` otherwise.
 function regenerate.open(session_obj, cookie)
   local id, usebefore, expires, data, hash = session_obj.storage:open(cookie, session_obj.cookie.lifetime)
   local now = time()


### PR DESCRIPTION
If a session is idle for more than this time, it will become
invalid. Setting 'idletime = 0` (default) will disable the new
behaviour.

It requires a new implementation of `touch` on all storage adapters.